### PR TITLE
📊 [gha] add godot-specific checks

### DIFF
--- a/.github/workflows/godot-checks.yml
+++ b/.github/workflows/godot-checks.yml
@@ -1,4 +1,4 @@
-name: Static Checks 📊
+name: Godot Checks 📊
 on:
   push:
     branches-ignore:
@@ -16,7 +16,7 @@ concurrency:
 permissions: {}
 
 jobs:
-  static-checks:
+  godot-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Done

- 📊 [gha] add godot-specific checks
- fix global GHA permissions
- rename to Godot Checks visibly to match filename


## Meta

(Automated in `.just/gh-process.just`.)


